### PR TITLE
SEPL IND -- Fix writing to peak end register

### DIFF
--- a/drivers/char/IND/IND-ioctl.c
+++ b/drivers/char/IND/IND-ioctl.c
@@ -61,13 +61,13 @@ int IND_Set_User_Mode(struct IND_drvdata *IND, struct IND_cmd_struct *cmd)
    IND_write_reg(IND, R_CAPTURE_COUNT_ADDR, (cmd->capture_count));
    IND_write_reg(IND, R_DELAY_COUNT_ADDR, (cmd->delay_count));
 
-   if (cmd->peak_detect_start > PEAK_SS_DISABLE)
-      IND_write_reg(IND, R_PEAK_START_ADDR, PEAK_SS_DISABLE);
+   if (cmd->peak_detect_start > PEAK_START_DISABLE)
+      IND_write_reg(IND, R_PEAK_START_ADDR, PEAK_START_DISABLE);
    else
       IND_write_reg(IND, R_PEAK_START_ADDR, cmd->peak_detect_start);
 
-   if (cmd->peak_detect_end > PEAK_SS_DISABLE)
-      IND_write_reg(IND, R_PEAK_START_ADDR, PEAK_SS_DISABLE);
+   if (cmd->peak_detect_end > PEAK_STOP_DISABLE)
+      IND_write_reg(IND, R_PEAK_END_ADDR, PEAK_STOP_DISABLE);
    else
       IND_write_reg(IND, R_PEAK_END_ADDR, cmd->peak_detect_end);
 

--- a/drivers/char/IND/IND-ioctl.c
+++ b/drivers/char/IND/IND-ioctl.c
@@ -53,7 +53,7 @@ int IND_Set_User_Mode(struct IND_drvdata *IND, struct IND_cmd_struct *cmd)
    else
        IND_write_reg(IND, R_INTERRUPT_ADDR, K_DISABLE_INTERRUPT);
 
-//   printk(KERN_DEBUG "IND_USER_SET_MODE: 0x%x 0x%x 0x%x 0x%x\n",cmd->config,cmd->address,cmd->capture_count,cmd->delay_count);
+   //printk(KERN_DEBUG "IND_USER_SET_MODE: config=0x%08x address=0x%08x capture_count=0x%08x delay_count=0x%08x peak_detect_start=0x%08x peak_detect_end=0x%08X\n", cmd->config, cmd->address, cmd->capture_count, cmd->delay_count, cmd->peak_detect_start, cmd->peak_detect_end);
 
    dma_size = cmd->capture_count * 6;
    IND_write_reg(IND, R_DMA_WRITE_ADDR, (IND->dma_handle + cmd->address));
@@ -71,10 +71,10 @@ int IND_Set_User_Mode(struct IND_drvdata *IND, struct IND_cmd_struct *cmd)
    else
       IND_write_reg(IND, R_PEAK_END_ADDR, cmd->peak_detect_end);
 
-
-   IND->config_state &= ~(ADC_TEST_DATA|PPS_DEBUG_MODE|DMA_DEBUG_MODE);
-   IND->config_state |= arg;
+   IND->config_state &= ~(CONFIG_MODE_MASK);
+   IND->config_state |= (arg & CONFIG_MODE_MASK);
    IND_write_reg(IND, R_MODE_CONFIG_ADDR, IND->config_state);
+   //printk(KERN_DEBUG "IND_USER_SET_MODE: config_state=0x%08x\n", IND->config_state);
 
    return 0;
 }

--- a/drivers/char/IND/IND.h
+++ b/drivers/char/IND/IND.h
@@ -45,7 +45,8 @@
 
 #define MODE_SIGNED              (SIGNED_DATA)
 
-#define PEAK_SS_DISABLE          0x00ffffff
+#define PEAK_START_DISABLE       0x00ffffff
+#define PEAK_STOP_DISABLE        0x00ffffff
 
 
 #define DISABLE_INTERRUPT        0

--- a/drivers/char/IND/IND.h
+++ b/drivers/char/IND/IND.h
@@ -22,12 +22,15 @@
 #define ADC_TEST_DATA            0x20
 #define PPS_DEBUG_MODE           0x40
 #define DMA_DEBUG_MODE           0x80
-#define DEBUG_SELECT_ACTIVE      0x800
 #define DEBUG_SELECT_CH0         0x000
 #define DEBUG_SELECT_CH1         0x100
 #define DEBUG_SELECT_CH2         0x200
 #define DEBUG_SELECT_CH_OFF      0x300
+#define DEBUG_SELECT_ACTIVE      0x800
 #define SIGNED_DATA              0x1000
+
+#define CONFIG_MODE_MASK         (ADC_TEST_DATA | PPS_DEBUG_MODE | DMA_DEBUG_MODE | DEBUG_SELECT_CH_OFF | DEBUG_SELECT_ACTIVE | SIGNED_DATA)
+
 
 #define MODE_NORMAL              0x00
 #define MODE_DMA_DEBUG           (DMA_DEBUG_MODE)

--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -143,6 +143,11 @@ else
 	cp arch/$ARCH/boot/$KBUILD_IMAGE "$tmpdir/$installed_image_path"
 fi
 
+## SEPL/BJS hack to install uImage in debian package.
+if [ -e arch/$ARCH/boot/uImage ]; then
+	cp arch/$ARCH/boot/uImage "$tmpdir/boot/uImage-$version"
+fi
+
 if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
 	INSTALL_MOD_PATH="$tmpdir" $MAKE KBUILD_SRC= modules_install
 	rm -f "$tmpdir/lib/modules/$version/build"


### PR DESCRIPTION
Please pull latest IND driver changes.
NOTE: we have move the SEPL work to a 'sepl' branch !!  I presume this pull request will do all the necessary magic.  You may want to pull into your own local 'sepl' branch.

This way al the SEPL changes are isolated from other work in xcomm_zynq.  Obviously we will merge xcomm_zynq into sepl as required.